### PR TITLE
Two typos in soe-cleanup.sh

### DIFF
--- a/soe-cleanup.sh
+++ b/soe-cleanup.sh
@@ -4,7 +4,7 @@
 
 
 # check if exists and if yes source the config file 
-if -f ~/.soe-config;
+if [ -f ~/.soe-config ];
 then
 	source ~/.soe-config
 else
@@ -16,7 +16,7 @@ fi
 # TODO this script can create a lot of damage. we have to ask if the user really wants to destroy the current organization with all its elements
 
 # remove content views
-for i in $(hammer --csv content-view list --full-results 1 --organization $ORG |  grep -e "^[0-9]*,.*" | awk -F, {'print $1'} )
+for i in $(hammer --csv content-view list --full-results 1 --organization "$ORG" |  grep -e "^[0-9]*,.*" | awk -F, {'print $1'} )
 do 
 	echo "Deleting content view ID $i";
 	# TOOD does not work, we need to remove from all envs before

--- a/soe-prep-setup.sh
+++ b/soe-prep-setup.sh
@@ -19,7 +19,7 @@ else
 fi
 
 
-# basically all long-duration tasks are now executed during step 1 and step 2
+# basically all long-duration tasks are now executed during step 1 and step 3
 DIR="$PWD"
 sh "${DIR}/step1.sh" && sh "${DIR}/step3.sh"
 


### PR DESCRIPTION
First: Missing 'test' command in the if. Fixing:

```
./soe-cleanup.sh: line 7: -f: command not found
```

Second: If org have whitespace in the name, this breaks. Fixing:

```
Error: too many arguments

See: 'hammer content-view list --help'
```
